### PR TITLE
fix #78

### DIFF
--- a/src/components/Main/MessageView/Titlebar.vue
+++ b/src/components/Main/MessageView/Titlebar.vue
@@ -12,11 +12,12 @@ header.titlebar
 export default {
   computed: {
     title () {
+      if (!this.$route.params.channel) return ''
       let ret = '#'
       this.$route.params.channel.split('/').slice(0, -1).forEach(e => {
         ret += e.charAt(0) + '/'
       })
-      ret += this.$route.params.channel.split('/').pop()
+      ret += this.$store.state.currentChannel.name
       return ret
     }
   }


### PR DESCRIPTION
'/'にアクセスしたときに`route.params.channel`がないことでエラーを出し、そのあとに'/channels/random'にアクセスしていたため