### PR TITLE
shows user icons of messages

### DIFF
--- a/src/bin/client.js
+++ b/src/bin/client.js
@@ -156,6 +156,9 @@ const client = {
       return axios.get(`/api/1.0/users/${userId}`)
     })
   },
+  getUserIconUrl (userId) {
+    return axios.defaults.baseURL + 'api/1.0/users/' + userId + '/icon'
+  },
 
   // Tag: clip
   getClipedMessages () {

--- a/src/components/Main/MessageView/MessageElement.vue
+++ b/src/components/Main/MessageView/MessageElement.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
 div.message
   div.message-user-icon-wrap
-    div.message-user-icon
+    img.message-user-icon(:src='userIconSrc')
   div.message-detail-wrap
     p.message-user-name
       | {{$store.state.memberMap[model.userId].name}}
@@ -102,6 +102,9 @@ export default {
     pinned () {
       this.pin = this.$store.getters.isPinned(this.model.messageId)
       return this.pin
+    },
+    userIconSrc () {
+      return client.getUserIconUrl(this.model.userId)
     }
   }
 }


### PR DESCRIPTION
メッセージのユーザーアイコンを表示させるようにした。(herokuのtraQサーバーはmasterがデプロイされる度にユーザーアイコンのファイルも吹き飛ばしてるらしい)