### PR TITLE
fix #341

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -8,6 +8,8 @@ div#app
 <script>
 import Splash from '@/components/Splash/Splash'
 import Favicon from '@/components/Util/Favicon'
+import 'normalize.css'
+import 'highlight.js/styles/default.css'
 export default {
   name: 'app',
   metaInfo: {

--- a/src/styles/global.sass
+++ b/src/styles/global.sass
@@ -1,8 +1,6 @@
-@import "~normalize.css"
 @import url("//fonts.googleapis.com/earlyaccess/mplus1p.css")
 @import url('https://fonts.googleapis.com/css?family=Oxygen+Mono')
-@import "highlight.js/styles/default.css"
-  
+
 $primary-color: #3a4891
 $secondary-color: #2c3e50
 $border-color: #b0b0b0


### PR DESCRIPTION
App.vueのscript内で*.cssを読むようにした

close #341 
