### PR TITLE
Disable theme feature on the browser without css custom properties

### DIFF
--- a/src/components/Main/MessageView/MessageElement/MessageElement.vue
+++ b/src/components/Main/MessageView/MessageElement/MessageElement.vue
@@ -476,7 +476,7 @@ export default {
   display: inline-flex
   align-items: center
   background: rgba(97, 97, 97, 0.1)
-  color: rgba(84, 84, 84, 0.77)
+  color: rgba(#{$text-color}, 0.77)
   padding: 2px 5px
   border-radius: 3px
   margin: 2px

--- a/src/components/Main/Sidebar/Footer.vue
+++ b/src/components/Main/Sidebar/Footer.vue
@@ -47,6 +47,10 @@ export default {
   margin-left: 1rem
   color: white
 
+@supports not (--primary-color: #232C26)
+  .menu-button.theme
+    display: none
+
 .version-text
   color: white
   font-size: 15px


### PR DESCRIPTION
CSS custom propertiesが実装されていないブラウザではテーマ機能を無効化する

@supportを使ってるのでIEではこれ自体うまく動かないけどまあIEなので