### PR TITLE
/files/のキャッシュ戦略を変更

### DIFF
--- a/static/sw.js
+++ b/static/sw.js
@@ -1,9 +1,31 @@
 workbox.skipWaiting()
 workbox.clientsClaim()
 
+// ファイルAPIのキャッシュ設定
 workbox.routing.registerRoute(
-  new RegExp('https://traq-dev.tokyotech.org/api/1.0/files'),
-  workbox.strategies.staleWhileRevalidate()
+  new RegExp('/api/1\\.0/files/[0-9a-fA-F-]{36}$'),
+  workbox.strategies.cacheFirst({
+    cacheName: 'files-cache',
+    plugins: [
+      new workbox.cacheableResponse.Plugin({
+        statuses: [0, 200],
+        headers: {
+          'X-TRAQ-FILE-CACHE': 'true'
+        }
+      })
+    ]
+  })
+)
+workbox.routing.registerRoute(
+  new RegExp('/api/1\\.0/files/[0-9a-fA-F-]{36}/thumbnail$'),
+  workbox.strategies.cacheFirst({
+    cacheName: 'thumbnail-cache',
+    plugins: [
+      new workbox.cacheableResponse.Plugin({
+        statuses: [0, 200]
+      })
+    ]
+  })
 )
 
 workbox.precaching.precacheAndRoute(self.__precacheManifest)


### PR DESCRIPTION
キャッシュするファイルを`X-TRAQ-FILE-CACHE`が`true`のファイル、サムネイル画像に制限。
cache-firstに変更
#348 