### PR TITLE
fix #542

### DIFF
--- a/src/bin/client.js
+++ b/src/bin/client.js
@@ -179,6 +179,11 @@ const client = {
       return axios.post(`/api/1.0/notification/device`, {token})
     })
   },
+  getMyNotifiedChannels () {
+    return middleWare('getMyNotifiedChannels', () => {
+      return axios.get('/api/1.0/users/me/notification')
+    })
+  },
 
   // Tag: user
   registerUser (name, password) {

--- a/src/components/Main/Modal/TagModal.vue
+++ b/src/components/Main/Modal/TagModal.vue
@@ -36,8 +36,14 @@ export default {
   computed: {
     ...mapState('modal', ['data']),
     ...mapGetters('modal', {
-      users: 'currentTagUsersSorted'
-    })
+      userIds: 'currentTagUsersSorted'
+    }),
+    ...mapGetters(['memberMap']),
+    users () {
+      return this.userIds
+        .filter(userId => this.memberMap[userId] && this.memberMap[userId].accountStatus !== 0)
+        .map(userId => this.memberMap[userId])
+    }
   }
 }
 </script>

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -82,6 +82,7 @@ const store = new Vuex.Store({
     currentChannelPinnedMessages: [],
     currentChannelNotifications: [],
     myNotifiedChannels: [],
+    myNotifiedChannelSet: new Set(),
     me: null,
     menuContent: 'Channels',
     heartbeatStatus: {userStatuses: []},
@@ -381,6 +382,11 @@ const store = new Vuex.Store({
     },
     setMyNotifiedChannels (state, channels) {
       state.myNotifiedChannels = channels
+      const set = new Set()
+      channels.forEach(channelId => {
+        set.add(channelId)
+      })
+      state.myNotifiedChannelSet = set
     },
     setChannelRecentMessages (state, data) {
       state.channelRecentMessages = data
@@ -764,9 +770,8 @@ const store = new Vuex.Store({
       commit('setChannelRecentMessages', res.data)
     },
     async updateMyNotifiedChannels ({commit, getters}) {
-      const res = await client.getNotifiedChannels(getters.getMyId)
+      const res = await client.getMyNotifiedChannels()
       const data = res.data
-      console.log(data)
       if (!data) return
       commit('setMyNotifiedChannels', data)
     },

--- a/src/store/modal.js
+++ b/src/store/modal.js
@@ -6,7 +6,7 @@ export default {
     name: null,
     data: null,
     currentUserTags: [],
-    currentTagUsers: [],
+    currentTagUserIds: [],
     lastUser: null
   },
   getters: {
@@ -16,7 +16,7 @@ export default {
       return current.filter(tag => !tag.editable).concat(current.filter(tag => tag.editable))
     },
     currentTagUsersSorted: state => {
-      return state.currentTagUsers
+      return state.currentTagUserIds
     }
   },
   mutations: {
@@ -33,9 +33,9 @@ export default {
       tags = tags || []
       state.currentUserTags = tags
     },
-    setCurrentTagUsers (state, users) {
+    setCurrentTagUserIds (state, users) {
       users = users || []
-      state.currentTagUsers = users
+      state.currentTagUserIds = users
     }
   },
   actions: {
@@ -45,9 +45,9 @@ export default {
         commit('setCurrentUserTags', res.data)
       })
     },
-    updateCurrentTagUsers ({state, commit}) {
+    updateCurrentTagUserIds ({state, commit}) {
       return client.getTag(state.data.tagId).then(res => {
-        commit('setCurrentTagUsers', res.data.users.filter(user => user.accountStatus !== 0))
+        commit('setCurrentTagUserIds', res.data.users)
       })
     },
     openUserModal: {
@@ -78,7 +78,7 @@ export default {
           name: 'TagModal',
           data: tag
         })
-        return dispatch('updateCurrentTagUsers')
+        return dispatch('updateCurrentTagUserIds')
       }
     },
     openChannelCreateModal: {


### PR DESCRIPTION
タグモーダルのユーザーをstate.memberMapから取得するように
自身の通知のつけているチャンネル取得を`users/me/notification`に変更
通知のついたチャンネルのsetを追加