### PR TITLE
fix #768

### DIFF
--- a/src/components/Main/MessageView/MessageInput.vue
+++ b/src/components/Main/MessageView/MessageInput.vue
@@ -600,7 +600,7 @@ $message-input-button-height-pc: 40px - 2px
     border:
       style: solid
       color: var(--tertiary-color-on-bg)
-      width: 1px
+      width: 2px
       radius: 8px
   padding:
     right: 6px


### PR DESCRIPTION
どうやら`border-width`が奇数pxだとChromeで発生するみたいです
偶数pxだと発生しないので`2px`に

よろしくお願いします