### PR TITLE
スタンプピッカーに意図していないスクロールバーが表示されるのを修正

### DIFF
--- a/src/components/Main/PickerModal/StampPicker.vue
+++ b/src/components/Main/PickerModal/StampPicker.vue
@@ -242,7 +242,7 @@ export default {
   width: 100%
   height: 100%
   padding: 6px 12px 6px
-  overflow: scroll
+  overflow: visible
 
 .stamp-picker-body-inner-wrapper
   display: flex


### PR DESCRIPTION
### before
![image](https://user-images.githubusercontent.com/49056869/57196529-ba21cc00-6f98-11e9-8c77-4a69673d8d89.png)

### after
![image](https://user-images.githubusercontent.com/49056869/57196539-cd349c00-6f98-11e9-95b8-626f9aa30ffc.png)
  
よろしくお願いします