### PR TITLE
チャンネルパスの順序が逆転する問題

### DIFF
--- a/src/components/Main/Sidebar/Content/ChannelDetailElement.vue
+++ b/src/components/Main/Sidebar/Content/ChannelDetailElement.vue
@@ -126,8 +126,6 @@ export default {
   z-index: 1
   user-select: none
   height: 34px
-  direction: rtl
-  text-align: left
 
   .channel-watched &
     color: $primary-color


### PR DESCRIPTION
長いチャンネル名を左側だけ省略させたかったが、directionの仕様が複雑だったので一度削除