### PR TITLE
macOSで変換確定のEnterで送信してしまうバグの修正 refs #791

### DIFF
--- a/src/bin/utils.js
+++ b/src/bin/utils.js
@@ -189,9 +189,15 @@ export const isSendKey = (keyEvent, messageSendKey) => {
   if (keyEvent.key !== 'Enter') {
     return false
   }
+  // messageSendKey === 'none'はisSendKeyInput()で処理
+  return messageSendKey === 'modifier' && withModifierKey(keyEvent)
+}
+export const isSendKeyInput = (inputEvent, messageSendKey) => {
+  // modifierが押されているときはisBRKey()を利用してpreventされる
   return (
-    (messageSendKey === 'modifier' && withModifierKey(keyEvent)) ||
-    (messageSendKey === 'none' && !withModifierKey(keyEvent))
+    messageSendKey === 'none' &&
+    inputEvent.inputType === 'insertLineBreak' &&
+    !isTouchDevice()
   )
 }
 export const isBRKey = (keyEvent, messageSendKey) => {

--- a/src/components/Main/MessageView/MessageElement/MessageElement.vue
+++ b/src/components/Main/MessageView/MessageElement/MessageElement.vue
@@ -40,7 +40,7 @@ article.message(v-if="!model.reported" ontouchstart="" :class="{'message-pinned'
       .message-text-wrap
         component(v-if="!isEditing" :is="renderedBody")
         .message-editing-wrap(v-if="isEditing")
-          textarea.input-reset.edit-area(v-model="edited" ref="editArea" @keydown="editKeydown" @keyup="editKeyup")
+          textarea.input-reset.edit-area(v-model="edited" ref="editArea" @input="editInput" @keydown="editKeydown" @keyup="editKeyup")
           button.edit-button.edit-cancel(@click.stop="editCancel")
             | Cancel
           button.edit-button.edit-submit(@click.stop="editSubmit")
@@ -74,6 +74,7 @@ import {
   withModifierKey,
   isModifierKey,
   isSendKey,
+  isSendKeyInput,
   isBRKey
 } from '@/bin/utils'
 import md from '@/bin/markdown-it'
@@ -129,6 +130,11 @@ export default {
         messageId: this.model.messageId
       })
       this.$store.commit('setStampPickerActive', true)
+    },
+    editInput(event) {
+      if (isSendKeyInput(event, this.messageSendKey)) {
+        this.editSubmit()
+      }
     },
     editKeydown(event) {
       if (withModifierKey(event)) {

--- a/src/components/Main/MessageView/MessageInput.vue
+++ b/src/components/Main/MessageView/MessageInput.vue
@@ -38,6 +38,7 @@
         v-model="inputText"
         @focus="inputFocus"
         @blur="inputBlur"
+        @input="input"
         @keydown="keydown"
         @keyup="keyup"
         @click="clearKey"
@@ -61,6 +62,7 @@ import {
   withModifierKey,
   isModifierKey,
   isSendKey,
+  isSendKeyInput,
   isBRKey
 } from '@/bin/utils'
 import suggest from '@/bin/suggest'
@@ -252,6 +254,17 @@ export default {
       this.key = {
         type: '',
         keyword: ''
+      }
+    },
+    input(event) {
+      if (this.postStatus === 'processing') {
+        event.returnValue = false
+        return
+      }
+      this.postStatus = 'default'
+      if (isSendKeyInput(event, this.messageSendKey)) {
+        this.submit()
+        event.returnValue = false
       }
     },
     keydown(event) {


### PR DESCRIPTION
とりあえずChromeのほうだけですが…
よろしくお願いします