### PR TITLE
`Modifier`+`Enter`で改行

### DIFF
--- a/src/bin/utils.js
+++ b/src/bin/utils.js
@@ -183,7 +183,7 @@ export const withModifierKey = keyEvent => {
   )
 }
 export const isModifierKey = keyEvent => {
-  return keyEvent.key === 'Shift' || 'Meta' || 'Alt'
+  return ['Shift', 'Meta', 'Alt'].includes(keyEvent.key)
 }
 export const isSendKey = (keyEvent, messageSendKey) => {
   if (keyEvent.key !== 'Enter') {
@@ -192,6 +192,13 @@ export const isSendKey = (keyEvent, messageSendKey) => {
   return (
     (messageSendKey === 'modifier' && withModifierKey(keyEvent)) ||
     (messageSendKey === 'none' && !withModifierKey(keyEvent))
+  )
+}
+export const isBRKey = (keyEvent, messageSendKey) => {
+  return (
+    messageSendKey === 'none' &&
+    keyEvent.key === 'Enter' &&
+    withModifierKey(keyEvent)
   )
 }
 

--- a/src/components/Main/MessageView/MessageElement/MessageElement.vue
+++ b/src/components/Main/MessageView/MessageElement/MessageElement.vue
@@ -73,7 +73,8 @@ import {
   displayDateTime,
   withModifierKey,
   isModifierKey,
-  isSendKey
+  isSendKey,
+  isBRKey
 } from '@/bin/utils'
 import md from '@/bin/markdown-it'
 import client from '@/bin/client'
@@ -135,6 +136,17 @@ export default {
       }
       if (isSendKey(event, this.messageSendKey)) {
         this.editSubmit()
+      }
+      if (isBRKey(event, this.messageSendKey)) {
+        event.preventDefault()
+        const pre = this.edited.substring(0, this.$refs.editArea.selectionStart)
+        const suf = this.edited.substring(this.$refs.editArea.selectionEnd)
+        this.edited = `${pre}\n${suf}`
+        this.$nextTick(() => {
+          this.$refs.editArea.selectionStart = this.$refs.editArea.selectionEnd =
+            pre.length + 1
+          autosize.update(this.$refs.editArea)
+        })
       }
     },
     editKeyup(event) {

--- a/src/components/Main/MessageView/MessageInput.vue
+++ b/src/components/Main/MessageView/MessageInput.vue
@@ -56,7 +56,13 @@
 import { mapGetters, mapState } from 'vuex'
 import autosize from 'autosize'
 import client from '@/bin/client'
-import { isImage, withModifierKey, isModifierKey, isSendKey } from '@/bin/utils'
+import {
+  isImage,
+  withModifierKey,
+  isModifierKey,
+  isSendKey,
+  isBRKey
+} from '@/bin/utils'
 import suggest from '@/bin/suggest'
 import stampAltNameTable from '@/bin/emoji_altname_table.json'
 import MessageTypingUsers from './MessageTypingUsers'
@@ -260,6 +266,20 @@ export default {
       if (isSendKey(event, this.messageSendKey)) {
         this.submit()
         event.returnValue = false
+      }
+      if (isBRKey(event, this.messageSendKey)) {
+        event.preventDefault()
+        const pre = this.inputText.substring(
+          0,
+          this.messageInput.selectionStart
+        )
+        const suf = this.inputText.substring(this.messageInput.selectionEnd)
+        this.inputText = `${pre}\n${suf}`
+        this.$nextTick(() => {
+          this.messageInput.selectionStart = this.messageInput.selectionEnd =
+            pre.length + 1
+          autosize.update(this.messageInput)
+        })
       }
       /*
       if (this.suggests.length === 0) {


### PR DESCRIPTION
`Enter`で送信する設定の際に`Meta`/`Alt`+`Enter`で改行できなかったのを修正しました
(`+Enterで改行`の表示も意図せずに`Shift`+`Enter`のときにしか出ていなかった)
よろしくお願いします