### PR TITLE
チャンネルパスのコピー機能の追加

### DIFF
--- a/src/components/Icon/IconCopy.vue
+++ b/src/components/Icon/IconCopy.vue
@@ -1,0 +1,38 @@
+<template functional>
+  <svg
+    :width="props.size"
+    :height="props.size"
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      fill-rule="evenodd"
+      clip-rule="evenodd"
+      d="M13.6667 9.33333H4.33333L4.33333 18.6667H13.6667V9.33333ZM4.33333 8C3.59695 8 3 8.59695 3 9.33333V18.6667C3 19.403 3.59695 20 4.33333 20H13.6667C14.403 20 15 19.403 15 18.6667V9.33333C15 8.59695 14.403 8 13.6667 8H4.33333Z"
+      :fill="props.color"
+    ></path>
+    <path
+      fill-rule="evenodd"
+      clip-rule="evenodd"
+      d="M16.3555 14.9L18.6778 14.9C19.408 14.9 20 14.308 20 13.5778L20 4.32225C20 3.592 19.408 3.00002 18.6778 3.00002L9.4222 3.00002C8.69195 3.00002 8.09998 3.592 8.09998 4.32225L8.09998 6.64439L9.4222 6.64439L9.4222 4.32225L18.6778 4.32225L18.6778 13.5778L16.3555 13.5778L16.3555 14.9Z"
+      :fill="props.color"
+    ></path>
+  </svg>
+</template>
+
+<script>
+export default {
+  name: 'IconCopy',
+  props: {
+    size: {
+      type: String,
+      default: '16'
+    },
+    color: {
+      type: String,
+      default: 'white'
+    }
+  }
+}
+</script>

--- a/src/components/Main/MessageView/Titlebar.vue
+++ b/src/components/Main/MessageView/Titlebar.vue
@@ -206,7 +206,7 @@ export default {
         window,
         'click',
         function(e) {
-          if (!this.$el.contains(e.target) && e.target.nodeName != 'BUTTON') {
+          if (!this.$el.contains(e.target) && e.target.nodeName !== 'BUTTON') {
             this.$store.commit('contractTitlebar')
           }
         }.bind(this)

--- a/src/components/Main/MessageView/Titlebar.vue
+++ b/src/components/Main/MessageView/Titlebar.vue
@@ -23,10 +23,6 @@ header.titlebar(ref="titlebar" :class="titlebarClass")
         icon-star(size="24")
       .titlebar-menu-button.border-left(v-show="!isDirectMessage && isStared" @click="unstarChannel")
         icon-star-fill(size="24")
-      .titlebar-menu-button.border-left.copy-channel-path(v-show="!isDirectMessage && !isCopyFake" @click="copyMessage")
-        icon-copy(size="24")
-      .titlebar-menu-button.border-left.copy-channel-path(v-show="!isDirectMessage && isCopyFake" @click="copyMessage")
-        icon-copy(size="24")
     .titlebar-menu-item(v-show="!isDirectMessage && !isNotificationForced" @click="$store.dispatch('openChannelNotificationModal')")
       .menu-icon
         icon-notification-fill(size="24")
@@ -37,6 +33,16 @@ header.titlebar(ref="titlebar" :class="titlebarClass")
         icon-plus(size="24")
       span
         | サブチャンネル作成
+    .titlebar-menu-item.copy-channel-path(v-show="!isDirectMessage && !isCopyFake" @click="copyMessage")
+      .menu-icon
+        icon-copy(size="24")
+      span
+        | チャンネルパスをコピー
+    .titlebar-menu-item.copy-channel-path(v-show="!isDirectMessage && isCopyFake" @click="copyMessage")
+      .menu-icon
+        icon-copy(size="24")
+      span
+        | チャンネルパスをコピー
 </template>
 
 <script>
@@ -234,12 +240,12 @@ $topic-height: 18px
   will-change: max-width, min-width
   +mq(pc)
     left: $sidebar-width
-    min-width: 230px
+    min-width: 260px
     max-width: calc( 100vw - #{$sidebar-width} - #{$information-sidebar-button-width} - 5px )
     height: 60px
   +mq(sp)
     // top: 10px
-    min-width: 200px
+    min-width: 230px
     max-width: calc( 100vw - #{$information-sidebar-button-width} - 5px )
     height: 50px
     &.is-sidebar-opened

--- a/src/components/Main/MessageView/Titlebar.vue
+++ b/src/components/Main/MessageView/Titlebar.vue
@@ -37,12 +37,12 @@ header.titlebar(ref="titlebar" :class="titlebarClass")
       .menu-icon
         icon-copy(size="24")
       span
-        | チャンネルパスをコピー
+        | チャンネルリンクをコピー
     .titlebar-menu-item.copy-channel-path(v-show="!isDirectMessage && isCopyFake" @click="copyMessage")
       .menu-icon
         icon-copy(size="24")
       span
-        | チャンネルパスをコピー
+        | チャンネルリンクをコピー
 </template>
 
 <script>

--- a/src/components/Main/MessageView/Titlebar.vue
+++ b/src/components/Main/MessageView/Titlebar.vue
@@ -245,7 +245,7 @@ $topic-height: 18px
     height: 60px
   +mq(sp)
     // top: 10px
-    min-width: 230px
+    min-width: 250px
     max-width: calc( 100vw - #{$information-sidebar-button-width} - 5px )
     height: 50px
     &.is-sidebar-opened

--- a/src/components/Main/MessageView/Titlebar.vue
+++ b/src/components/Main/MessageView/Titlebar.vue
@@ -24,7 +24,7 @@ header.titlebar(ref="titlebar" :class="titlebarClass")
       .titlebar-menu-button.border-left(v-show="!isDirectMessage && isStared" @click="unstarChannel")
         icon-star-fill(size="24")
       .titlebar-menu-button.border-left#clip(v-show="!isDirectMessage" @click="copyMessage")
-        icon-attach(size="24")
+        icon-copy(size="24")
     .titlebar-menu-item(v-show="!isDirectMessage && !isNotificationForced" @click="$store.dispatch('openChannelNotificationModal')")
       .menu-icon
         icon-notification-fill(size="24")
@@ -46,7 +46,7 @@ import IconNotification from '@/components/Icon/IconNotification'
 import IconStar from '@/components/Icon/IconStar'
 import IconStarFill from '@/components/Icon/IconStarFill'
 import IconPlus from '@/components/Icon/IconPlus'
-import IconAttach from '@/components/Icon/IconAttach'
+import IconCopy from '@/components/Icon/IconCopy'
 
 export default {
   name: 'Titlebar',
@@ -57,7 +57,7 @@ export default {
     IconStar,
     IconStarFill,
     IconPlus,
-    IconAttach
+    IconCopy
   },
   data() {
     return {
@@ -202,9 +202,7 @@ export default {
         window,
         'click',
         function(e) {
-          console.log('~~~~~~~~~~~~~')
-          console.log(e.target)
-          if (!this.$el.contains(e.target)) {
+          if (!this.$el.contains(e.target) && e.target.nodeName != 'BUTTON') {
             this.$store.commit('contractTitlebar')
           }
         }.bind(this)

--- a/src/components/Main/MessageView/Titlebar.vue
+++ b/src/components/Main/MessageView/Titlebar.vue
@@ -33,12 +33,7 @@ header.titlebar(ref="titlebar" :class="titlebarClass")
         icon-plus(size="24")
       span
         | サブチャンネル作成
-    .titlebar-menu-item.copy-channel-path(v-show="!isDirectMessage && !isCopyFake" @click="copyMessage")
-      .menu-icon
-        icon-copy(size="24")
-      span
-        | チャンネルリンクをコピー
-    .titlebar-menu-item.copy-channel-path(v-show="!isDirectMessage && isCopyFake" @click="copyMessage")
+    .titlebar-menu-item.copy-channel-path(v-show="!isDirectMessage" @click="copyMessage")
       .menu-icon
         icon-copy(size="24")
       span
@@ -69,8 +64,7 @@ export default {
   },
   data() {
     return {
-      width: 0,
-      isCopyFake: true
+      width: 0
     }
   },
   methods: {
@@ -111,7 +105,6 @@ export default {
         })
     },
     copyMessage() {
-      this.isCopyFake = !this.isCopyFake
       this.$copyText(
         `[#${this.$route.params.channel}](https://q.trap.jp/channels/${
           this.$route.params.channel

--- a/src/components/Main/MessageView/Titlebar.vue
+++ b/src/components/Main/MessageView/Titlebar.vue
@@ -23,8 +23,10 @@ header.titlebar(ref="titlebar" :class="titlebarClass")
         icon-star(size="24")
       .titlebar-menu-button.border-left(v-show="!isDirectMessage && isStared" @click="unstarChannel")
         icon-star-fill(size="24")
-      .titlebar-menu-button.border-left#clip(v-show="!isDirectMessage" @click="copyMessage")
+      .titlebar-menu-button.border-left.clip(v-show="!isDirectMessage && !isCopyFake" @click="copyMessage")
         icon-copy(size="24")
+      .titlebar-menu-button.border-left.clip(v-show="!isDirectMessage && isCopyFake" @click="copyMessage")
+        icon-copy(size="24" color="white")
     .titlebar-menu-item(v-show="!isDirectMessage && !isNotificationForced" @click="$store.dispatch('openChannelNotificationModal')")
       .menu-icon
         icon-notification-fill(size="24")
@@ -61,7 +63,8 @@ export default {
   },
   data() {
     return {
-      width: 0
+      width: 0,
+      isCopyFake: true
     }
   },
   methods: {
@@ -102,6 +105,11 @@ export default {
         })
     },
     copyMessage() {
+      if (this.isCopyFake) {
+        this.isCopyFake = false
+      } else {
+        this.isCopyFake = true
+      }
       this.$copyText(
         `[#${this.$route.params.channel}](https://q.trap.jp/channels/${
           this.$route.params.channel
@@ -364,6 +372,8 @@ $topic-height: 18px
     cursor: pointer
     &:hover
       background: rgba(0,0,0,0.1)
+  .clip:active
+    background-color: rgba(0,0,0,0.2)
 
 .border-left
   position: relative
@@ -414,7 +424,4 @@ $topic-height: 18px
 
   &:hover
     background: rgba(0,0,0,0.1)
-
-#clip:active
-  background-color: rgba(0,0,0,0.3)
 </style>

--- a/src/components/Main/MessageView/Titlebar.vue
+++ b/src/components/Main/MessageView/Titlebar.vue
@@ -23,8 +23,8 @@ header.titlebar(ref="titlebar" :class="titlebarClass")
         icon-star(size="24")
       .titlebar-menu-button.border-left(v-show="!isDirectMessage && isStared" @click="unstarChannel")
         icon-star-fill(size="24")
-      .titlebar-menu-button.border-left(v-show="!isDirectMessage" @click="copyMessage")
-        icon-star(size="24")
+      .titlebar-menu-button.border-left#clip(v-show="!isDirectMessage" @click="copyMessage")
+        icon-attach(size="24")
     .titlebar-menu-item(v-show="!isDirectMessage && !isNotificationForced" @click="$store.dispatch('openChannelNotificationModal')")
       .menu-icon
         icon-notification-fill(size="24")
@@ -46,6 +46,7 @@ import IconNotification from '@/components/Icon/IconNotification'
 import IconStar from '@/components/Icon/IconStar'
 import IconStarFill from '@/components/Icon/IconStarFill'
 import IconPlus from '@/components/Icon/IconPlus'
+import IconAttach from '@/components/Icon/IconAttach'
 
 export default {
   name: 'Titlebar',
@@ -55,7 +56,8 @@ export default {
     IconNotification,
     IconStar,
     IconStarFill,
-    IconPlus
+    IconPlus,
+    IconAttach
   },
   data() {
     return {
@@ -100,22 +102,11 @@ export default {
         })
     },
     copyMessage() {
-      /*function sleep(waitMsec) {
-        var startMsec = new Date()
-
-        // 指定ミリ秒間だけループさせる（CPUは常にビジー状態）
-        while (new Date() - startMsec < waitMsec);
-      }*/
-
       this.$copyText(
         `[#${this.$route.params.channel}](https://q.trap.jp/channels/${
           this.$route.params.channel
         })`
       )
-      /*client.unstarChannel(this.currentChannelId).then(() => {
-        this.$store.dispatch('updateStaredChannels')
-      })*/
-      //sleep(2000)
     },
     removeWidth() {
       this.$refs.titlebarInner.style.width = ''
@@ -425,4 +416,7 @@ $topic-height: 18px
 
   &:hover
     background: rgba(0,0,0,0.1)
+
+#clip:active
+  background-color: rgba(0,0,0,0.3)
 </style>

--- a/src/components/Main/MessageView/Titlebar.vue
+++ b/src/components/Main/MessageView/Titlebar.vue
@@ -374,8 +374,6 @@ $topic-height: 18px
     cursor: pointer
     &:hover
       background: rgba(0,0,0,0.1)
-  .copy-channel-path:active
-    background-color: rgba(0,0,0,0.2)
 
 .border-left
   position: relative
@@ -404,6 +402,9 @@ $topic-height: 18px
     margin-right: 15px
   &:hover
       background: rgba(0,0,0,0.1)
+.copy-channel-path:active
+  background-color: rgba(0,0,0,0.2)
+
 
 .traq-logo
   width: 25px

--- a/src/components/Main/MessageView/Titlebar.vue
+++ b/src/components/Main/MessageView/Titlebar.vue
@@ -23,10 +23,8 @@ header.titlebar(ref="titlebar" :class="titlebarClass")
         icon-star(size="24")
       .titlebar-menu-button.border-left(v-show="!isDirectMessage && isStared" @click="unstarChannel")
         icon-star-fill(size="24")
-      .titlebar-menu-button.border-left(v-show="!isDirectMessage && !isStared" @click="copyMessage")
+      .titlebar-menu-button.border-left(v-show="!isDirectMessage" @click="copyMessage")
         icon-star(size="24")
-      .titlebar-menu-button.border-left(v-show="!isDirectMessage && isStared" @click="unstarChannel")
-        icon-star-fill(size="24")
     .titlebar-menu-item(v-show="!isDirectMessage && !isNotificationForced" @click="$store.dispatch('openChannelNotificationModal')")
       .menu-icon
         icon-notification-fill(size="24")
@@ -102,7 +100,22 @@ export default {
         })
     },
     copyMessage() {
-      this.$copyText(`#${this.$route.params.channel}`)
+      /*function sleep(waitMsec) {
+        var startMsec = new Date()
+
+        // 指定ミリ秒間だけループさせる（CPUは常にビジー状態）
+        while (new Date() - startMsec < waitMsec);
+      }*/
+
+      this.$copyText(
+        `[#${this.$route.params.channel}](https://q.trap.jp/channels/${
+          this.$route.params.channel
+        })`
+      )
+      /*client.unstarChannel(this.currentChannelId).then(() => {
+        this.$store.dispatch('updateStaredChannels')
+      })*/
+      //sleep(2000)
     },
     removeWidth() {
       this.$refs.titlebarInner.style.width = ''
@@ -142,9 +155,6 @@ export default {
       return this.$store.state.currentChannel.channelId
     },
     isDirectMessage() {
-      console.log('~~~~~~~~~~~~~~~~~~~')
-      console.log(this.$store.state.currentChannel.parent)
-      console.log(this.$store.state.directMessageId)
       return (
         this.$store.state.currentChannel.parent ===
         this.$store.state.directMessageId
@@ -201,6 +211,8 @@ export default {
         window,
         'click',
         function(e) {
+          console.log('~~~~~~~~~~~~~')
+          console.log(e.target)
           if (!this.$el.contains(e.target)) {
             this.$store.commit('contractTitlebar')
           }

--- a/src/components/Main/MessageView/Titlebar.vue
+++ b/src/components/Main/MessageView/Titlebar.vue
@@ -23,6 +23,10 @@ header.titlebar(ref="titlebar" :class="titlebarClass")
         icon-star(size="24")
       .titlebar-menu-button.border-left(v-show="!isDirectMessage && isStared" @click="unstarChannel")
         icon-star-fill(size="24")
+      .titlebar-menu-button.border-left(v-show="!isDirectMessage && !isStared" @click="copyMessage")
+        icon-star(size="24")
+      .titlebar-menu-button.border-left(v-show="!isDirectMessage && isStared" @click="unstarChannel")
+        icon-star-fill(size="24")
     .titlebar-menu-item(v-show="!isDirectMessage && !isNotificationForced" @click="$store.dispatch('openChannelNotificationModal')")
       .menu-icon
         icon-notification-fill(size="24")
@@ -97,6 +101,9 @@ export default {
           this.$store.dispatch('updateMyNotifiedChannels')
         })
     },
+    copyMessage() {
+      this.$copyText(`#${this.$route.params.channel}`)
+    },
     removeWidth() {
       this.$refs.titlebarInner.style.width = ''
     },
@@ -135,6 +142,9 @@ export default {
       return this.$store.state.currentChannel.channelId
     },
     isDirectMessage() {
+      console.log('~~~~~~~~~~~~~~~~~~~')
+      console.log(this.$store.state.currentChannel.parent)
+      console.log(this.$store.state.directMessageId)
       return (
         this.$store.state.currentChannel.parent ===
         this.$store.state.directMessageId

--- a/src/components/Main/MessageView/Titlebar.vue
+++ b/src/components/Main/MessageView/Titlebar.vue
@@ -23,10 +23,10 @@ header.titlebar(ref="titlebar" :class="titlebarClass")
         icon-star(size="24")
       .titlebar-menu-button.border-left(v-show="!isDirectMessage && isStared" @click="unstarChannel")
         icon-star-fill(size="24")
-      .titlebar-menu-button.border-left.clip(v-show="!isDirectMessage && !isCopyFake" @click="copyMessage")
+      .titlebar-menu-button.border-left.copy-channel-path(v-show="!isDirectMessage && !isCopyFake" @click="copyMessage")
         icon-copy(size="24")
-      .titlebar-menu-button.border-left.clip(v-show="!isDirectMessage && isCopyFake" @click="copyMessage")
-        icon-copy(size="24" color="white")
+      .titlebar-menu-button.border-left.copy-channel-path(v-show="!isDirectMessage && isCopyFake" @click="copyMessage")
+        icon-copy(size="24")
     .titlebar-menu-item(v-show="!isDirectMessage && !isNotificationForced" @click="$store.dispatch('openChannelNotificationModal')")
       .menu-icon
         icon-notification-fill(size="24")
@@ -105,11 +105,7 @@ export default {
         })
     },
     copyMessage() {
-      if (this.isCopyFake) {
-        this.isCopyFake = false
-      } else {
-        this.isCopyFake = true
-      }
+      this.isCopyFake = !this.isCopyFake
       this.$copyText(
         `[#${this.$route.params.channel}](https://q.trap.jp/channels/${
           this.$route.params.channel
@@ -372,7 +368,7 @@ $topic-height: 18px
     cursor: pointer
     &:hover
       background: rgba(0,0,0,0.1)
-  .clip:active
+  .copy-channel-path:active
     background-color: rgba(0,0,0,0.2)
 
 .border-left


### PR DESCRIPTION
#774 
タイトルバーメニューボタンのところにチャンネルパスをコピーするボタンを追加しました。パスはmd形式でコピーするようにしています。`[#チャンネルパス](https://q.trap.jp/channels/チャンネルパス)`
よろしくお願いします