### PR TITLE
トピック編集をキャンセルすると.information-sidebarが閉じるバグの修正 close #784

### DIFF
--- a/src/components/Main/MessageView/InformationSidebar/InformationSidebar.vue
+++ b/src/components/Main/MessageView/InformationSidebar/InformationSidebar.vue
@@ -156,7 +156,7 @@ export default {
         window,
         'click',
         function(e) {
-          if (!this.$el.contains(e.target)) {
+          if (e.target.parentElement && !this.$el.contains(e.target)) {
             this.isOpened = false
           }
         }.bind(this)


### PR DESCRIPTION
よろしくお願いします

バグの原因は #784 に

close #784 