### PR TITLE
チャンネルパスのコピー機能の修正

### DIFF
--- a/src/components/Main/MessageView/Titlebar.vue
+++ b/src/components/Main/MessageView/Titlebar.vue
@@ -106,9 +106,7 @@ export default {
     },
     copyMessage() {
       this.$copyText(
-        `[#${this.$route.params.channel}](https://q.trap.jp/channels/${
-          this.$route.params.channel
-        })`
+        `[#${this.$route.params.channel}](${window.location.href})`
       )
     },
     removeWidth() {

--- a/src/components/Main/MessageView/Titlebar.vue
+++ b/src/components/Main/MessageView/Titlebar.vue
@@ -106,7 +106,9 @@ export default {
     },
     copyMessage() {
       this.$copyText(
-        `[#${this.$route.params.channel}](${window.location.href})`
+        `[#${this.$route.params.channel}](${location.origin}${
+          this.$route.path
+        })`
       )
     },
     removeWidth() {


### PR DESCRIPTION
#894 
urlを直接`http://q.trap.jp`と指定していたのをlocationオブジェクトから取得するように変更しました