### PR TITLE
 Enterでメッセージ送信時にEnterをすると改行が挿入されてから送信されるバグの修正

### DIFF
--- a/src/bin/utils.js
+++ b/src/bin/utils.js
@@ -185,13 +185,6 @@ export const withModifierKey = keyEvent => {
 export const isModifierKey = keyEvent => {
   return ['Shift', 'Alt', 'Control', 'Meta'].includes(keyEvent.key)
 }
-export const isSendKey = (keyEvent, messageSendKey) => {
-  if (keyEvent.key !== 'Enter') {
-    return false
-  }
-  // messageSendKey === 'none'はisSendKeyInput()で処理
-  return messageSendKey === 'modifier' && withModifierKey(keyEvent)
-}
 export const isSendKeyInput = (inputEvent, messageSendKey) => {
   // modifierが押されているときはisBRKey()を利用してpreventされる
   return (

--- a/src/components/Main/MessageView/MessageElement/MessageElement.vue
+++ b/src/components/Main/MessageView/MessageElement/MessageElement.vue
@@ -73,7 +73,6 @@ import {
   displayDateTime,
   withModifierKey,
   isModifierKey,
-  isSendKey,
   isSendKeyInput,
   isBRKey
 } from '@/bin/utils'
@@ -143,8 +142,19 @@ export default {
       if (withModifierKey(event)) {
         this.isPushedModifierKey = true
       }
-      if (isSendKey(event, this.messageSendKey)) {
-        this.editSubmit()
+      if (event.key === 'Enter') {
+        if (this.messageSendKey === 'modifier' && withModifierKey(event)) {
+          this.editSubmit()
+          return
+        }
+        if (this.messageSendKey === 'none' && !withModifierKey(event)) {
+          event.preventDefault()
+          // 改行を防ぐためにeventをpreventするとinputイベントが発火せず送信判定ができないので手動で発火
+          this.editInput(
+            new InputEvent('input', { inputType: 'insertLineBreak' })
+          )
+          return
+        }
       }
       if (isBRKey(event, this.messageSendKey)) {
         event.preventDefault()

--- a/src/components/Main/MessageView/MessageInput.vue
+++ b/src/components/Main/MessageView/MessageInput.vue
@@ -257,19 +257,17 @@ export default {
     },
     input(event) {
       if (this.postStatus === 'processing') {
-        event.returnValue = false
         return
       }
       this.postStatus = 'default'
       // 変換確定のEnterかどうかのためにInputイベントで判定する
       if (isSendKeyInput(event, this.messageSendKey)) {
         this.submit()
-        event.returnValue = false
       }
     },
     keydown(event) {
       if (this.postStatus === 'processing') {
-        event.returnValue = false
+        event.preventDefault()
         return
       }
       this.postStatus = 'default'
@@ -278,12 +276,12 @@ export default {
       }
       if (event.key === 'Enter') {
         if (this.messageSendKey === 'modifier' && withModifierKey(event)) {
+          event.preventDefault()
           this.submit()
-          event.returnValue = false
           return
         }
         if (this.messageSendKey === 'none' && !withModifierKey(event)) {
-          event.returnValue = false
+          event.preventDefault()
           // 改行を防ぐためにeventをpreventするとinputイベントが発火せず送信判定ができないので手動で発火
           this.input(new InputEvent('input', { inputType: 'insertLineBreak' }))
           return
@@ -312,7 +310,7 @@ export default {
           if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
             this.suggestMode = true
             this.suggestIndex = 0
-            event.returnValue = false
+            event.preventDefault()
             return
           }
         } else {
@@ -328,11 +326,11 @@ export default {
             if (this.suggestIndex >= this.suggests.length) {
               this.suggestIndex = this.suggests.length - 1
             }
-            event.returnValue = false
+            event.preventDefault()
             return
           } else if (event.key === 'Enter') {
             this.replaceSuggest(this.suggestIndex)
-            event.returnValue = false
+            event.preventDefault()
             return
           }
         }
@@ -347,7 +345,7 @@ export default {
         (event.ctrlKey || event.metaKey || event.shiftKey)
       ) {
         this.submit()
-        event.returnValue = false
+        event.preventDefault()
       } else {
         this.$nextTick(() => {
           const selectionStart = this.messageInput.selectionStart

--- a/src/components/Main/MessageView/MessageInput.vue
+++ b/src/components/Main/MessageView/MessageInput.vue
@@ -61,7 +61,6 @@ import {
   isImage,
   withModifierKey,
   isModifierKey,
-  isSendKey,
   isSendKeyInput,
   isBRKey
 } from '@/bin/utils'
@@ -262,6 +261,7 @@ export default {
         return
       }
       this.postStatus = 'default'
+      // 変換確定のEnterかどうかのためにInputイベントで判定する
       if (isSendKeyInput(event, this.messageSendKey)) {
         this.submit()
         event.returnValue = false
@@ -276,9 +276,18 @@ export default {
       if (withModifierKey(event)) {
         this.isPushedModifierKey = true
       }
-      if (isSendKey(event, this.messageSendKey)) {
-        this.submit()
-        event.returnValue = false
+      if (event.key === 'Enter') {
+        if (this.messageSendKey === 'modifier' && withModifierKey(event)) {
+          this.submit()
+          event.returnValue = false
+          return
+        }
+        if (this.messageSendKey === 'none' && !withModifierKey(event)) {
+          event.returnValue = false
+          // 改行を防ぐためにeventをpreventするとinputイベントが発火せず送信判定ができないので手動で発火
+          this.input(new InputEvent('input', { inputType: 'insertLineBreak' }))
+          return
+        }
       }
       if (isBRKey(event, this.messageSendKey)) {
         event.preventDefault()

--- a/src/components/Main/Modal/UserModal/UserModalTags.vue
+++ b/src/components/Main/Modal/UserModal/UserModalTags.vue
@@ -77,7 +77,7 @@ export default {
         (event.ctrlKey || event.metaKey || event.shiftKey)
       ) {
         this.addTag()
-        event.returnValue = false
+        event.preventDefault()
       }
     },
     addTag() {


### PR DESCRIPTION
タイトルのバグの修正とともに`input`イベントは`cancelable`でないのに`event.returnValue = false`されていたのを除去したのと、`event.returnValue`はFirefoxで使えないので`event.preventDefault()`に書き換えました

よろしくお願いします