### PR TITLE
DMフィルタの改善

### DIFF
--- a/src/components/Main/Sidebar/Content/MemberGroup.vue
+++ b/src/components/Main/Sidebar/Content/MemberGroup.vue
@@ -5,7 +5,7 @@
         | {{groupName}}
     div.member-group-list(ref="list")
       transition(name="simple" @after-enter="removeHeight" @after-leave="zeroHeight")
-        div(ref="listWrap" v-show="isOpen || filterUnread")
+        div(ref="listWrap" v-show="isOpen || filterUnread || filterText !== ''")
           template(v-if="filterUnread")
             member-element(v-for="member in filteredUnreadMembers" :model="member" :key="member.userId")
           template(v-else)


### PR DESCRIPTION
1. DMの文字列フィルター時は展開されるように
    - 閉じていたときにフィルタするとどこにヒットしたものがあるかいちいち開かないと確認できなかった
1. DMの未読フィルタ時でもグループの開閉ができるように
    - 未読フィルタ/1.の文字列フィルタをかけている状態でグループの開閉ができず開いた状態で固定されていた

よろしくお願いします