### PR TITLE
Enterで送信時に2行目以降で変換時に送信されるのを修正 fix #939

### DIFF
--- a/src/bin/utils.js
+++ b/src/bin/utils.js
@@ -201,6 +201,13 @@ export const isBRKey = (keyEvent, messageSendKey) => {
   )
 }
 
+// https://github.com/ianstormtaylor/slate/blob/7377266b43451c4be44a1442aa1076ef3d13227e/packages/slate-dev-environment/src/index.js#L74-L79
+export const checkLevel2InputEventsSupport = () => {
+  const element = document.createElement('div')
+  element.contentEditable = true
+  return 'onbeforeinput' in element
+}
+
 export const isTouchDevice = () => {
   const userAgent = navigator.userAgent
   return (

--- a/src/components/Main/MessageView/MessageElement/MessageElement.vue
+++ b/src/components/Main/MessageView/MessageElement/MessageElement.vue
@@ -106,6 +106,7 @@ export default {
   data() {
     return {
       isEditing: false,
+      editedTemp: '',
       files: [],
       messages: [],
       isRendered: false,
@@ -135,6 +136,7 @@ export default {
     },
     editInput(event) {
       if (isSendKeyInput(event, this.messageSendKey)) {
+        this.edited = this.editedTemp
         this.editSubmit()
       }
     },
@@ -148,11 +150,7 @@ export default {
           return
         }
         if (this.messageSendKey === 'none' && !withModifierKey(event)) {
-          event.preventDefault()
-          // 改行を防ぐためにeventをpreventするとinputイベントが発火せず送信判定ができないので手動で発火
-          this.editInput(
-            new InputEvent('input', { inputType: 'insertLineBreak' })
-          )
+          this.editedTemp = this.edited
           return
         }
       }

--- a/src/components/Main/MessageView/MessageElement/MessageElement.vue
+++ b/src/components/Main/MessageView/MessageElement/MessageElement.vue
@@ -40,7 +40,7 @@ article.message(v-if="!model.reported" ontouchstart="" :class="{'message-pinned'
       .message-text-wrap
         component(v-if="!isEditing" :is="renderedBody")
         .message-editing-wrap(v-if="isEditing")
-          textarea.input-reset.edit-area(v-model="edited" ref="editArea" @input="editInput" @keydown="editKeydown" @keyup="editKeyup")
+          textarea.input-reset.edit-area(v-model="edited" ref="editArea" @beforeinput="editBeforeinput" @keydown="editKeydown" @keyup="editKeyup")
           button.edit-button.edit-cancel(@click.stop="editCancel")
             | Cancel
           button.edit-button.edit-submit(@click.stop="editSubmit")
@@ -74,7 +74,8 @@ import {
   withModifierKey,
   isModifierKey,
   isSendKeyInput,
-  isBRKey
+  isBRKey,
+  checkLevel2InputEventsSupport
 } from '@/bin/utils'
 import md from '@/bin/markdown-it'
 import client from '@/bin/client'
@@ -87,6 +88,8 @@ import IconPin from '@/components/Icon/IconPin'
 import IconStampPlus from '@/components/Icon/IconStampPlus'
 import IconPen from '@/components/Icon/IconPen'
 import autosize from 'autosize'
+
+const isLevel2InputEventsSupported = checkLevel2InputEventsSupport()
 
 export default {
   name: 'MessageElement',
@@ -134,9 +137,9 @@ export default {
       }
       this.$store.commit('setStampPickerActive', true)
     },
-    editInput(event) {
+    editBeforeinput(event) {
       if (isSendKeyInput(event, this.messageSendKey)) {
-        this.edited = this.editedTemp
+        event.preventDefault()
         this.editSubmit()
       }
     },
@@ -144,17 +147,24 @@ export default {
       if (withModifierKey(event)) {
         this.isPushedModifierKey = true
       }
-      if (event.key === 'Enter') {
+      // #945
+      if (event.key === 'Enter' && !event.isComposing) {
         if (this.messageSendKey === 'modifier' && withModifierKey(event)) {
+          event.preventDefault()
           this.editSubmit()
           return
         }
-        if (this.messageSendKey === 'none' && !withModifierKey(event)) {
-          this.editedTemp = this.edited
+        if (
+          this.messageSendKey === 'none' &&
+          !withModifierKey(event) &&
+          !isLevel2InputEventsSupported
+        ) {
+          event.preventDefault()
+          this.editSubmit()
           return
         }
       }
-      if (isBRKey(event, this.messageSendKey)) {
+      if (isBRKey(event, this.messageSendKey) && !event.isComposing) {
         event.preventDefault()
         const pre = this.edited.substring(0, this.$refs.editArea.selectionStart)
         const suf = this.edited.substring(this.$refs.editArea.selectionEnd)

--- a/src/components/Main/MessageView/MessageInput.vue
+++ b/src/components/Main/MessageView/MessageInput.vue
@@ -38,6 +38,7 @@
         v-model="inputText"
         @focus="inputFocus"
         @blur="inputBlur"
+        @beforeinput="beforeinput"
         @input="input"
         @keydown="keydown"
         @keyup="keyup"
@@ -62,7 +63,8 @@ import {
   withModifierKey,
   isModifierKey,
   isSendKeyInput,
-  isBRKey
+  isBRKey,
+  checkLevel2InputEventsSupport
 } from '@/bin/utils'
 import suggest from '@/bin/suggest'
 import stampAltNameTable from '@/bin/emoji_altname_table.json'
@@ -74,6 +76,8 @@ import IconHash from '@/components/Icon/IconHash'
 import IconProfile from '@/components/Icon/IconProfile'
 import IconFile from '@/components/Icon/IconFile'
 import IconClose from '@/components/Icon/IconClose'
+
+const isLevel2InputEventsSupported = checkLevel2InputEventsSupport()
 
 export default {
   name: 'MessageInput',
@@ -95,7 +99,6 @@ export default {
       postLock: false,
       uploadedIds: [],
       messageInput: null,
-      inputTextTemp: '',
       key: {
         keyword: '',
         type: ''
@@ -256,16 +259,17 @@ export default {
         keyword: ''
       }
     },
+    beforeinput(event) {
+      if (isSendKeyInput(event, this.messageSendKey)) {
+        event.preventDefault()
+        this.submit()
+      }
+    },
     input(event) {
       if (this.postStatus === 'processing') {
         return
       }
       this.postStatus = 'default'
-      // 変換確定のEnterかどうかのためにInputイベントで判定する
-      if (isSendKeyInput(event, this.messageSendKey)) {
-        this.inputText = this.inputTextTemp
-        this.submit()
-      }
     },
     keydown(event) {
       if (this.postStatus === 'processing') {
@@ -276,18 +280,24 @@ export default {
       if (withModifierKey(event)) {
         this.isPushedModifierKey = true
       }
-      if (event.key === 'Enter') {
+      // #945
+      if (event.key === 'Enter' && !event.isComposing) {
         if (this.messageSendKey === 'modifier' && withModifierKey(event)) {
           event.preventDefault()
           this.submit()
           return
         }
-        if (this.messageSendKey === 'none' && !withModifierKey(event)) {
-          this.inputTextTemp = this.inputText
+        if (
+          this.messageSendKey === 'none' &&
+          !withModifierKey(event) &&
+          !isLevel2InputEventsSupported
+        ) {
+          event.preventDefault()
+          this.submit()
           return
         }
       }
-      if (isBRKey(event, this.messageSendKey)) {
+      if (isBRKey(event, this.messageSendKey) && !event.isComposing) {
         event.preventDefault()
         const pre = this.inputText.substring(
           0,

--- a/src/components/Main/MessageView/MessageInput.vue
+++ b/src/components/Main/MessageView/MessageInput.vue
@@ -95,6 +95,7 @@ export default {
       postLock: false,
       uploadedIds: [],
       messageInput: null,
+      inputTextTemp: '',
       key: {
         keyword: '',
         type: ''
@@ -262,6 +263,7 @@ export default {
       this.postStatus = 'default'
       // 変換確定のEnterかどうかのためにInputイベントで判定する
       if (isSendKeyInput(event, this.messageSendKey)) {
+        this.inputText = this.inputTextTemp
         this.submit()
       }
     },
@@ -281,9 +283,7 @@ export default {
           return
         }
         if (this.messageSendKey === 'none' && !withModifierKey(event)) {
-          event.preventDefault()
-          // 改行を防ぐためにeventをpreventするとinputイベントが発火せず送信判定ができないので手動で発火
-          this.input(new InputEvent('input', { inputType: 'insertLineBreak' }))
+          this.inputTextTemp = this.inputText
           return
         }
       }


### PR DESCRIPTION
よろしくお願いします

~~追記 できてなかったっぽいので一旦保留で…~~
追追記 できてたみたい

## メモ
chrome/safariはbeforeinputが存在
firefoxは存在しない

keydown -> beforeinput -> inputの順

Level2InputEventsがサポートされていれば`beforeinput`が存在してさらにそれがcancelableになっている
https://github.com/ianstormtaylor/slate/blob/9694b228464d8b4d874074496a4c0a50f6ec4614/packages/slate-dev-environment/src/index.js#L74-L79

beforeinputの存在の確認はできない

safariでは変換確定のEnterでkeydownのisComposingがfalse

## 処理
|設定|`modifier`|`none`|
|---|---|---|
|送信|`keydown`: modifierが押されているか確認して(改行防止のpreventDefaultして)送信<br>`beforeinput`: なにもしない<br>`input`: なにもしない|`keydown`: modifierがない場合でbeforeinputがサポートされていない場合でcomposingでない場合は送信してpreventDefaultで`beforeinput`/`input`を防止<br>`beforeinput`: 変換確定か確認して送信<br>`input`: なにもしない|
|改行|`keydown`: なにもしない<br>`beforeinput`: なにもしない<br>`input`: なにもしない|`keydown`: modifierを確認して改行を挿入(このときの処理でinputは発生しない)してpreventDefaultで送信されるのを防止<br>`beforeinput`: なにもしない<br>`input`: なにもしない|