### PR TITLE
ダークモードでのハイライトの変更 close #883

### DIFF
--- a/src/styles/_theme.sass
+++ b/src/styles/_theme.sass
@@ -1,4 +1,6 @@
 #app[data-theme="light"]
+  @import '~highlight.js/styles/atom-one-light'
+
   --primary-color: #{$default-primary-color}
   --secondary-color: #{$default-secondary-color}
   --tertiary-color: #{$default-tertiary-color}
@@ -39,6 +41,8 @@
   --key-shadow-color: #999999
 
 #app[data-theme="dark"]
+  @import '~highlight.js/styles/atom-one-dark'
+
   --primary-color: #232C36
   --secondary-color: #161C23
   --tertiary-color: #060C13

--- a/src/styles/global.sass
+++ b/src/styles/global.sass
@@ -3,7 +3,6 @@
 
 @import url('https://fonts.googleapis.com/css?family=Noto+Sans+JP')
 
-@import 'highlight.js/styles/default.css'
 @import 'reset.scss'
 
 @import '_theme'


### PR DESCRIPTION
 - light
![image](https://user-images.githubusercontent.com/49056869/61119891-bd748f00-a4d6-11e9-9c1c-28aaa06c672b.png)

 - dark
![image](https://user-images.githubusercontent.com/49056869/61119907-c6656080-a4d6-11e9-813f-287296f49803.png)

light時には`atom-one-light`、dark時には`atom-one-dark`になるようになってます

よろしくお願いします