### PR TITLE
markdownのパースをwebworkerで行うように

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1437,6 +1437,11 @@
         }
       }
     },
+    "@ungap/event-target": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@ungap/event-target/-/event-target-0.1.0.tgz",
+      "integrity": "sha512-W2oyj0Fe1w/XhPZjkI3oUcDUAmu5P4qsdT2/2S8aMhtAWM/CE/jYWtji0pKNPDfxLI75fa5gWSEmnynKMNP/oA=="
+    },
     "@vue/babel-helper-vue-jsx-merge-props": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@vue/babel-helper-vue-jsx-merge-props/-/babel-helper-vue-jsx-merge-props-1.0.0.tgz",
@@ -1878,6 +1883,7 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
+        "node-releases": {},
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -2952,8 +2958,7 @@
     "big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
-      "dev": true
+      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
     },
     "binary-extensions": {
       "version": "1.13.1",
@@ -5259,8 +5264,7 @@
     "emojis-list": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
-      "dev": true
+      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -9494,7 +9498,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
       "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
-      "dev": true,
       "requires": {
         "big.js": "^5.2.2",
         "emojis-list": "^2.0.0",
@@ -9505,7 +9508,6 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-          "dev": true,
           "requires": {
             "minimist": "^1.2.0"
           }
@@ -10059,8 +10061,7 @@
     "minimist": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-      "dev": true
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mississippi": {
       "version": "3.0.0",
@@ -15498,6 +15499,14 @@
       "dev": true,
       "requires": {
         "errno": "~0.1.7"
+      }
+    },
+    "workerize-loader": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/workerize-loader/-/workerize-loader-1.1.0.tgz",
+      "integrity": "sha512-cU2jPVE3AzzVxOonBe9lCCO//qwE9s/K4a9njFVRLueznzNDNND5vGHVorGuzK6xvamdDOZ9+g7CPIc7QKzucQ==",
+      "requires": {
+        "loader-utils": "^1.2.3"
       }
     },
     "wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "gen-unicode_emojis": "node build/gen-unicode_emojis"
   },
   "dependencies": {
+    "@ungap/event-target": "^0.1.0",
     "core-js": "^2.6.9",
     "firebase": "^6.5.0",
     "lodash": "^4.17.15",
@@ -24,7 +25,8 @@
     "vue-class-component": "^7.1.0",
     "vue-property-decorator": "^8.2.2",
     "vue-router": "^3.1.3",
-    "vuex": "^3.1.1"
+    "vuex": "^3.1.1",
+    "workerize-loader": "^1.0.4"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "^3.11.0",

--- a/src/bin/markdown.js
+++ b/src/bin/markdown.js
@@ -1,0 +1,81 @@
+import Md from 'workerize-loader!@/worker/markdown-it'
+
+class Renderer {
+  constructor() {
+    this.worker = new Md()
+  }
+  async getInitializedWorker() {
+    await this.worker.getInitializePromise()
+    return this.worker
+  }
+  async updateData(key, val) {
+    ;(await this.getInitializedWorker()).updateData(key, val)
+  }
+  async render(text) {
+    return (await this.getInitializedWorker()).render(text)
+  }
+  initialize(states) {
+    return this.worker.initialize(states)
+  }
+  stop() {
+    this.worker.terminate()
+  }
+}
+
+class RendererManager {
+  renderers = new Map()
+  constructor() {
+    this.spareRenderer = new Renderer()
+  }
+  initialize(states) {
+    this.states = states
+
+    for (const r of this.renderers.values()) {
+      r.initialize(this.states)
+    }
+    this.spareRenderer.initialize(this.states)
+  }
+  createRenderer(scope) {
+    this.renderers.set(scope, this.spareRenderer)
+    this.spareRenderer = new Renderer()
+    if (this.states) {
+      this.spareRenderer.initialize(this.states)
+    }
+  }
+  updateData(key, val) {
+    for (const r of this.renderers.values()) {
+      r.updateData(key, val)
+    }
+    this.spareRenderer.updateData(key, val)
+  }
+  async getImportStates() {
+    return this.spareRenderer.worker.getImportStates()
+  }
+  async render(scope, text) {
+    if (!this.renderers.has(scope)) {
+      this.createRenderer(scope)
+    }
+    return this.renderers.get(scope).render(text)
+  }
+  stop(scope) {
+    if (this.renderers.has(scope)) {
+      const renderer = this.renderers.get(scope)
+      renderer.stop()
+      this.renderers.delete(scope)
+    } else {
+      console.warn(
+        `unpredicted scope was set. set: ${scope}. exists: ${Array.from(
+          this.renderers.keys()
+        ).join(',')}}`
+      )
+    }
+  }
+}
+export const rendererManager = new RendererManager()
+
+export const inlineRenderer = new Renderer()
+
+export const renderInline = async text => {
+  const ir = await inlineRenderer.getInitializedWorker()
+  return ir.renderInline(text)
+}

--- a/src/components/Main/MessageView/InformationSidebar/SlimMessageElement.vue
+++ b/src/components/Main/MessageView/InformationSidebar/SlimMessageElement.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
   div.slim-message-element(
-    :class="{'is-overflow': isOverflow}" 
+    :class="{'is-overflow': isOverflow}"
     @click.stop.prevent="openModal")
     div
       | {{userName}}
@@ -8,7 +8,8 @@
 </template>
 
 <script>
-import md from '@/bin/markdown-it'
+import { rendererManager } from '@/bin/markdown'
+
 export default {
   name: 'SlimMessageElement',
   props: {
@@ -19,7 +20,8 @@ export default {
   },
   data() {
     return {
-      height: 0
+      height: 0,
+      renderedContent: null
     }
   },
   computed: {
@@ -31,13 +33,6 @@ export default {
     },
     content() {
       return this.message.content
-    },
-    renderedContent() {
-      return {
-        template: `<div class="slim-message-content markdown-body" v-pre>${md.render(
-          this.content
-        )}</div>`
-      }
     },
     isOverflow() {
       return this.height >= 110
@@ -51,10 +46,24 @@ export default {
     },
     openModal() {
       this.$store.dispatch('openMessageModal', this.message)
+    },
+    async setContent(val) {
+      this.renderedContent = {
+        template: `<div class="slim-message-content markdown-body" v-pre>${await rendererManager.render(
+          this.$store.state.currentChannel.channelId,
+          val
+        )}</div>`
+      }
+    }
+  },
+  watch: {
+    content(val) {
+      this.setContent(val)
     }
   },
   mounted() {
     this.height = this.$el.offsetHeight
+    this.setContent(this.content)
   }
 }
 </script>

--- a/src/components/Main/MessageView/MessageContainer.vue
+++ b/src/components/Main/MessageView/MessageContainer.vue
@@ -21,6 +21,7 @@
 </template>
 
 <script>
+import { rendererManager } from '@/bin/markdown'
 import MessageElement from './MessageElement/MessageElement'
 import { throttle } from 'lodash'
 
@@ -123,10 +124,11 @@ export default {
     }
   },
   watch: {
-    currentChannel() {
+    currentChannel(val, oldVal) {
       this.messageLoading = false
       this.noMoreMessage = false
       this.isFirstView = true
+      rendererManager.stop(oldVal.channelId)
     }
   }
 }

--- a/src/components/Main/MessageView/MessageElement/AttachedMessages.vue
+++ b/src/components/Main/MessageView/MessageElement/AttachedMessages.vue
@@ -24,7 +24,7 @@
 
 <script>
 import { mapGetters, mapActions } from 'vuex'
-import md from '@/bin/markdown-it'
+import { rendererManager } from '@/bin/markdown'
 
 export default {
   name: 'AttachedMessages',
@@ -39,11 +39,10 @@ export default {
       renderedBodies: []
     }
   },
-  mounted() {
-    this.renderedBodies = this.messages
-      .filter(m => m)
-      .map(m => this.mark(m.content))
-    this.$emit('rendered')
+  async mounted() {
+    this.renderedBodies = await Promise.all(
+      this.messages.map(m => this.mark(m.content))
+    )
   },
   computed: {
     ...mapGetters(['userDisplayName', 'fileUrl'])
@@ -60,9 +59,10 @@ export default {
     userDetail(userId) {
       return this.$store.state.memberMap[userId]
     },
-    mark(text) {
+    async mark(text) {
       return {
-        template: `<div class="message-content markdown-body" v-pre>${md.render(
+        template: `<div class="message-content markdown-body" v-pre>${await rendererManager.render(
+          this.$store.state.currentChannel.channelId,
           text
         )}</div>`,
         props: this.$options.props

--- a/src/components/Main/MessageView/MessageElement/MessageContentBody.vue
+++ b/src/components/Main/MessageView/MessageElement/MessageContentBody.vue
@@ -3,7 +3,7 @@
 </template>
 
 <script>
-import md from '@/bin/markdown-it'
+import { rendererManager } from '@/bin/markdown'
 
 export default {
   props: {
@@ -12,10 +12,26 @@ export default {
       default: ''
     }
   },
-  computed: {
-    renderedContent() {
-      return md.render(this.content)
+  data() {
+    return {
+      renderedContent: ''
     }
+  },
+  methods: {
+    async render() {
+      this.renderedContent = await rendererManager.render(
+        this.$store.state.currentChannel.channelId,
+        this.content
+      )
+    }
+  },
+  watch: {
+    content() {
+      this.render()
+    }
+  },
+  created() {
+    this.render()
   }
 }
 </script>

--- a/src/components/Main/Sidebar/Content/ChannelActivityElement.vue
+++ b/src/components/Main/Sidebar/Content/ChannelActivityElement.vue
@@ -19,7 +19,7 @@ div.channel-activity-wrap
 </template>
 
 <script>
-import { renderInline } from '@/bin/markdown-it'
+import { renderInline } from '@/bin/markdown'
 import { detectFiles } from '@/bin/utils'
 import IconAttach from '@/components/Icon/IconAttach'
 import IconSpeechBalloon from '@/components/Icon/IconSpeechBalloon'
@@ -35,6 +35,11 @@ export default {
   props: {
     model: Object
   },
+  data() {
+    return {
+      sanitizedMessage: ''
+    }
+  },
   methods: {
     channelLink() {
       this.$store.commit('closeSidebar')
@@ -44,6 +49,9 @@ export default {
           this.model.parentChannelId
         )}`
       )
+    },
+    async render() {
+      this.sanitizedMessage = await renderInline(this.content)
     }
   },
   computed: {
@@ -73,7 +81,7 @@ export default {
       return { 'has-unread': this.unreadNum > 0 }
     },
     attachments() {
-      return detectFiles(this.model.content)
+      return detectFiles(this.content)
     },
     hasMessage() {
       return this.attachments.filter(a => a.type === 'message').length > 0
@@ -81,9 +89,17 @@ export default {
     hasFile() {
       return this.attachments.filter(a => a.type === 'file').length > 0
     },
-    sanitizedMessage() {
-      return renderInline(this.model.content)
+    content() {
+      return this.model.content
     }
+  },
+  watch: {
+    content() {
+      this.render()
+    }
+  },
+  created() {
+    this.render()
   }
 }
 </script>

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -5,6 +5,7 @@ import client from '@/bin/client'
 import indexedDB from '@/bin/indexeddb'
 import stampCategorizer from '@/bin/stampCategorizer'
 import { detectMentions, caseIntensiveEquals, Trie } from '@/bin/utils'
+import { rendererManager, inlineRenderer } from '@/bin/markdown'
 import modal from './modal'
 import pickerModal from './pickerModal'
 import messageInput from './messageInput'
@@ -53,6 +54,29 @@ const stringSortGen = key => (lhs, rhs) => {
     return 1
   } else {
     return 0
+  }
+}
+
+;(async () => {
+  const states = await rendererManager.getImportStates()
+  const data = Object.entries(store.state).filter(([key]) =>
+    states.includes(key)
+  )
+  rendererManager.initialize(data)
+  inlineRenderer.initialize(data)
+})()
+
+const markdownDataPlugin = async store => {
+  const states = await rendererManager.getImportStates()
+  for (const name of states) {
+    store.watch(
+      state => state[name],
+      newVal => {
+        console.log('update', name, newVal)
+        rendererManager.updateData(name, newVal)
+        inlineRenderer.updateData(name, newVal)
+      }
+    )
   }
 }
 
@@ -1272,7 +1296,8 @@ const store = new Vuex.Store({
         data: ecoModeEnabled
       })
     }
-  }
+  },
+  plugins: [markdownDataPlugin]
 })
 
 window.openUserModal = userId => {

--- a/src/worker/markdown-it-json.js
+++ b/src/worker/markdown-it-json.js
@@ -1,4 +1,4 @@
-import store from '@/store/index'
+import * as store from '@/worker/store'
 import json from 'markdown-it-json'
 
 const validate = data => {
@@ -9,11 +9,11 @@ const validate = data => {
   ) {
     return false
   }
-  if (data['type'] === 'user' && store.state.memberMap[data['id']]) {
+  if (data['type'] === 'user' && store.getMember(data['id'])) {
     return true
-  } else if (data['type'] === 'channel' && store.state.channelMap[data['id']]) {
+  } else if (data['type'] === 'channel' && store.getChannel(data['id'])) {
     return true
-  } else if (data['type'] === 'group' && store.state.groupMap[data['id']]) {
+  } else if (data['type'] === 'group' && store.getGroup(data['id'])) {
     return true
   } else if (data['type'] === 'file' || data['type'] === 'message') {
     return true
@@ -24,10 +24,10 @@ const validate = data => {
 const transform = (state, data) => {
   const attributes = []
   const meta = { type: data['type'], data: '' }
-  if (data['type'] === 'user' && store.state.memberMap[data['id']]) {
+  if (data['type'] === 'user' && store.getMember(data['id'])) {
     attributes.push(['href', `javascript:openUserModal('${data['id']}')`])
     meta.data = data['id']
-    if (data['id'] === store.state.me.userId) {
+    if (data['id'] === store.getMe().userId) {
       attributes.push([
         'class',
         'message-user-link-highlight message-user-link'
@@ -42,11 +42,11 @@ const transform = (state, data) => {
     t = state.push('text', '', 0)
     t.content = data['raw']
     state.push('traq_extends_link_close', 'a', -1)
-  } else if (data['type'] === 'channel' && store.state.channelMap[data['id']]) {
+  } else if (data['type'] === 'channel' && store.getChannel(data['id'])) {
     attributes.push([
       'href',
-      `javascript:changeChannel('${store.getters.getChannelPathById(
-        store.state.channelMap[data['id']].channelId
+      `javascript:changeChannel('${store.getChannelPath(
+        store.getChannel(data['id']).channelId
       )}')`
     ])
     attributes.push(['class', 'message-channel-link'])
@@ -58,12 +58,12 @@ const transform = (state, data) => {
     t = state.push('text', '', 0)
     t.content = data['raw']
     state.push('traq_extends_link_close', 'a', -1)
-  } else if (data['type'] === 'group' && store.state.groupMap[data['id']]) {
+  } else if (data['type'] === 'group' && store.getGroup(data['id'])) {
     attributes.push(['href', `javascript:openGroupModal('${data['id']}')`])
     if (
-      store.state.groupMap[data['id']].members.filter(
-        userId => userId === store.state.me.userId
-      ).length > 0
+      store
+        .getGroup(data['id'])
+        .members.filter(userId => userId === store.getMe().userId).length > 0
     ) {
       attributes.push([
         'class',

--- a/src/worker/markdown-it.js
+++ b/src/worker/markdown-it.js
@@ -1,12 +1,26 @@
 import MarkdownIt from 'markdown-it'
 import hljs from 'highlight.js'
 import MarkdownItMark from 'markdown-it-mark'
-import json from '@/bin/markdown-it-json'
+import json from '@/worker/markdown-it-json'
 import regexp from 'markdown-it-regexp'
-import store from '@/store/index'
 import mila from 'markdown-it-link-attributes'
 import filter from 'markdown-it-image-filter'
 import whitelist from '@/bin/domain_whitelist.json'
+import * as store from '@/worker/store'
+
+// exportできるのは関数のみ(asyncでくるまれるので)
+export const updateData = (key, val) => {
+  store.update(key, val)
+}
+export const initialize = states => {
+  store.initialize(states)
+}
+export const getImportStates = () => {
+  return store.importStates
+}
+export const getInitializePromise = () => {
+  return store.initializePromise
+}
 
 function highlight(code, lang) {
   const [langName, langCaption] = lang.split(':')
@@ -178,18 +192,18 @@ const renderEmoji = match => {
   const stampName = splitted[0]
   const effects = splitted.length > 1 ? splitted.slice(1) : []
 
-  if (store.state.stampNameMap[stampName]) {
+  if (store.getStampFromName(stampName)) {
     // 通常スタンプ
     return renderEmojiDom(
       match[0],
       stampName,
-      store.state.stampNameMap[stampName].name,
-      `/api/1.0/files/${store.state.stampNameMap[stampName].fileId}`,
+      store.getStampFromName(stampName).name,
+      `/api/1.0/files/${store.getStampFromName(stampName).fileId}`,
       effects
     )
-  } else if (store.getters.getUserByName(stampName)) {
+  } else if (store.getUserByName(stampName)) {
     // ユーザーアイコン
-    const user = store.getters.getUserByName(stampName)
+    const user = store.getUserByName(stampName)
     return renderEmojiDom(
       match[0],
       stampName,
@@ -218,7 +232,9 @@ md.use(mila, {
 })
 md.use(filter(whitelist))
 
-export default md
+export const render = text => {
+  return md.render(text, {})
+}
 
 export const renderInline = text => {
   const parsed = md.parseInline(text, {})

--- a/src/worker/store.js
+++ b/src/worker/store.js
@@ -1,0 +1,70 @@
+import EventTarget from '@ungap/event-target'
+
+const data = new Map([
+  ['stampNameMap', []],
+  ['memberData', []],
+  ['memberMap', {}],
+  ['channelMap', {}],
+  ['groupMap', {}],
+  ['me', {}]
+])
+
+export const importStates = [...data.keys()]
+
+export const update = (key, val) => {
+  data.set(key, val)
+}
+
+export const initialize = states => {
+  for (const [key, val] of states) {
+    update(key, val)
+  }
+  initializeTarget.dispatchEvent(new Event('initialized'))
+}
+
+let initializeTarget = new EventTarget()
+export const initializePromise = new Promise(resolve => {
+  initializeTarget.addEventListener('initialized', e => {
+    resolve()
+  })
+})
+
+const get = key => {
+  return data.get(key)
+}
+
+export const getStampFromName = name => {
+  return get('stampNameMap')[name]
+}
+
+export const getUserByName = name => {
+  return get('memberData').find(user => user.name === name) || null
+}
+
+export const getMember = id => {
+  return get('memberMap')[id]
+}
+
+export const getChannel = id => {
+  return get('channelMap')[id]
+}
+
+export const getGroup = id => {
+  return get('groupMap')[id]
+}
+
+export const getChannelPath = id => {
+  let current = getChannel(id)
+  let path = current.name
+  let next = getChannel(current.parent)
+  while (next.name) {
+    path = next.name + '/' + path
+    current = next
+    next = getChannel(current.parent)
+  }
+  return path
+}
+
+export const getMe = () => {
+  return get('me')
+}


### PR DESCRIPTION
動きはするのですが、
ソースが闇深すぎるというのと
HMRあたりがおかしな挙動をするので
とりあえずドラフトで

#955 からのブランチです

---
#### メモ
 - 76bd360: worker一つ、同期するデータの指定が分散
 - d7181ba: 同期するデータの指定をworker側に
 - 69068de: データの読み込みがされずにレンダリングが走ることがあるバグの修正
 - 090e323: Proxy -> EventTarget(EventTargetの存在思いつかなかった)
 - 7ec3ece: hmrが効かないのを修正
 - 25c2fe9: アクティビティがレンダリンクされていないのを修正
 - fb71bec: レンダリングの直列化とAbortControllerを利用したabortの実装(abortしても実行開始済みのレンダリングが止まらない問題)
 - 1d2d1ee: abortとレンダリングをraceしてabortをより早くすることの試み(少しははやくなったたぶん)
 - becb0a7: fb71bec + 1d2d1ee をrevertした上でWorkerの生成ラグがないように常に2つのWorkerを立ち上げてチャンネルが切り替わった地点でそのWorkerを捨てることで瞬間的にabortするように。(アクティビティで一つとさらにもう一つ別のWorkerが存在しているので実際には4つのWorkerが動く)
 - f75b9c9: ピン留めが表示されないのを修正
 - 6845033: ファイル名変更