### PR TITLE
ピン留めのメッセージの表示ができないのを修正 fix #968

### DIFF
--- a/src/components/Main/Modal/PinnedModal.vue
+++ b/src/components/Main/Modal/PinnedModal.vue
@@ -21,8 +21,10 @@ export default {
   computed: {
     ...mapState('modal', ['data']),
     message() {
-      return this.$store.state.messages.find(
-        m => m.messageId === this.data.messageId
+      return (
+        this.$store.state.messages.find(
+          m => m.messageId === this.data.messageId
+        ) || this.data
       )
     }
   }


### PR DESCRIPTION
表示されていない過去のメッセージがピン留めされているとき、
それがピン留めから表示できないのを修正しました

よろしくお願いします

refs #929