### PR TITLE
ログインのエラー文が左寄せになっていたのを修正

### DIFF
--- a/src/pages/Login/Login.vue
+++ b/src/pages/Login/Login.vue
@@ -288,6 +288,7 @@ export default {
 
   .login-failed-message
     position: absolute
+    text-align: center
     bottom: 0
     transform: translateY(calc(100% ))
     display: block
@@ -423,6 +424,7 @@ export default {
 
   .login-failed-message
     position: absolute
+    text-align: center
     bottom: 0
     transform: translateY(calc(100% + 20px ))
     display: block


### PR DESCRIPTION
 - before
![image](https://user-images.githubusercontent.com/49056869/61513336-c534b600-aa37-11e9-995d-cf8ea8932ed0.png)
 - after
![image](https://user-images.githubusercontent.com/49056869/61513370-daa9e000-aa37-11e9-94f1-e96e9bcd27e9.png)

PCはたぶん中央寄せを意図してるとおもうんですが、
スマホの方は左寄せでも問題なさそうですが、
一応変えました

 - sp(before)
![image](https://user-images.githubusercontent.com/49056869/61513555-74718d00-aa38-11e9-9369-2066edd65bd3.png)

よろしくお願いします