### PR TITLE
手元にないピン留めされているメッセージを編集してもすぐに表示に適用されないのを修正

### DIFF
--- a/src/components/Main/Modal/PinnedModal.vue
+++ b/src/components/Main/Modal/PinnedModal.vue
@@ -21,11 +21,10 @@ export default {
   computed: {
     ...mapState('modal', ['data']),
     message() {
-      return (
-        this.$store.state.messages.find(
-          m => m.messageId === this.data.messageId
-        ) || this.data
+      const pinned = this.$store.state.currentChannelPinnedMessages.find(
+        ({ message }) => message.messageId === this.data.messageId
       )
+      return pinned ? pinned.message : this.data
     }
   }
 }


### PR DESCRIPTION
ref #929 #969 
手元にあるメッセージはモーダルで編集後に表示が適用されますが、
手元にないものは適用されていませんでした
よろしくお願いします