### PR TITLE
チャンネル移動をすると二回historyに積まれる問題を修正 close #993

### DIFF
--- a/src/bin/utils.js
+++ b/src/bin/utils.js
@@ -220,10 +220,40 @@ export const isTouchDevice = () => {
   )
 }
 
-export const changeHash = hash => {
+import store from '../store'
+export const changeHash = (hash, data) => {
   let path = window.location.pathname
+  const curHash = window.location.hash
+  console.log(data)
   if (hash !== '') {
     path += `#${hash}`
+    if (!data.fromState) {
+      if (curHash === '#PickerModal') {
+        history.replaceState(
+          { name: hash, data: { fromState: true, ...data } },
+          document.title,
+          path
+        )
+      } else {
+        history.pushState(
+          { name: hash, data: { fromState: true, ...data } },
+          document.title,
+          path
+        )
+      }
+    }
+  } else {
+    if (data.type) {
+      store.commit('modal/setClose', data.type)
+    }
+
+    if (curHash !== '' && store.state.modal.close === 'all') {
+      window.history.back()
+    } else if (curHash !== '' && store.state.modal.close === 'single') {
+      store.commit('modal/setClose', '')
+      window.history.back()
+    } else {
+      store.commit('modal/setClose', '')
+    }
   }
-  history.pushState('', document.title, path)
 }

--- a/src/bin/utils.js
+++ b/src/bin/utils.js
@@ -221,30 +221,30 @@ export const isTouchDevice = () => {
 }
 
 import store from '../store'
-export const changeHash = (hash, data) => {
+export const changeHash = (hash, data, option = {}) => {
   let path = window.location.pathname
   const curHash = window.location.hash
   console.log(data)
   if (hash !== '') {
     path += `#${hash}`
-    if (!data.fromState) {
+    if (!option.fromState) {
       if (curHash === '#PickerModal') {
         history.replaceState(
-          { name: hash, data: { fromState: true, ...data } },
+          { name: hash, data, option: { fromState: true } },
           document.title,
           path
         )
       } else {
         history.pushState(
-          { name: hash, data: { fromState: true, ...data } },
+          { name: hash, data, option: { fromState: true } },
           document.title,
           path
         )
       }
     }
   } else {
-    if (data.type) {
-      store.commit('modal/setClose', data.type)
+    if (option.type) {
+      store.commit('modal/setClose', option.type)
     }
 
     if (curHash !== '' && store.state.modal.close === 'all') {

--- a/src/components/Main/Modal/BaseCommonModal.vue
+++ b/src/components/Main/Modal/BaseCommonModal.vue
@@ -4,7 +4,7 @@
     .common-modal-header(:class="{'common-modal-header-back': enableBack}" @click="handleHeaderClick")
       slot(name="header-icon")
       h1.common-modal-header-title {{ title }}
-    .common-modal-close(@click="close")
+    .common-modal-close(@click="close('all')")
       icon-close(color="var(--primary-color-on-bg)" size="12")
   .common-modal-content(:class="{'is-scroll': scroll}")
     slot

--- a/src/components/Main/Modal/index.vue
+++ b/src/components/Main/Modal/index.vue
@@ -2,7 +2,7 @@
 .modal-container(v-if="isActive")
   .modal-overlay(
     :style="overlayStyle"
-    @click.self="close"
+    @click.self="close('all')"
   )
   component.modal(
     :is="name"

--- a/src/pages/Main/Main.vue
+++ b/src/pages/Main/Main.vue
@@ -21,6 +21,7 @@ import client from '@/bin/client'
 import ActionDetector from '@/components/Util/ActionDetector'
 import MessageView from '@/components/Main/MessageView'
 import Sidebar from '@/components/Main/Sidebar/Sidebar'
+import { changeHash } from '../../bin/utils'
 
 export default {
   name: 'Main',
@@ -149,6 +150,15 @@ export default {
           this.$store.dispatch('getMessages', true)
           this.$store.dispatch('updateUnreadMessages')
         })
+      }
+    }
+
+    window.onpopstate = e => {
+      if (e.state && e.state.name) {
+        this.$store.dispatch('modal/open', e.state)
+      } else {
+        this.$store.commit('setStampPickerActive', false)
+        this.$store.dispatch('modal/close', {})
       }
     }
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -130,6 +130,12 @@ router.beforeEach(async (to, from, next) => {
 
   store.commit('setPinnedModal', false)
 
+  if (from.path === to.path) {
+    store.commit('loadEnd')
+    next(true)
+    return
+  }
+
   if (to.params.user) {
     const nextUser = store.getters.getUserByName(to.params.user)
     if (nextUser) {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -66,6 +66,10 @@ const router = new Router({
 router.beforeEach(async (to, from, next) => {
   store.dispatch('modal/close')
 
+  if (location.hash !== '') {
+    history.replaceState(null, document.title, location.pathname)
+  }
+
   if (!store.state.me) {
     await store.dispatch('whoAmI')
   }

--- a/src/store/modal.js
+++ b/src/store/modal.js
@@ -152,8 +152,8 @@ export default {
         })
       }
     },
-    open({ state, commit }, { name, data }) {
-      changeHash(name, data)
+    open({ state, commit }, { name, data, option }) {
+      changeHash(name, data, option)
       if (state.name === 'UserModal') {
         // Transition from user modal
         commit('setLastUser', state.data)
@@ -162,7 +162,7 @@ export default {
       commit('setModalData', data)
     },
     close({ commit }, type) {
-      changeHash('', { type })
+      changeHash('', null, { type })
       commit('setModalName', null)
       commit('setLastUser', null)
       commit('setModalData', null)

--- a/src/store/modal.js
+++ b/src/store/modal.js
@@ -10,7 +10,8 @@ export default {
     currentTagUserIds: [],
     currentUserGroupIds: [],
     lastUser: null,
-    qrLastLoad: null
+    qrLastLoad: null,
+    close: ''
   },
   getters: {
     isActive: state => !!state.name,
@@ -57,6 +58,9 @@ export default {
     setCurrentUserGroupIds(state, groups) {
       groups = groups || []
       state.currentUserGroupIds = groups
+    },
+    setClose(state, close) {
+      state.close = close
     }
   },
   actions: {
@@ -149,7 +153,7 @@ export default {
       }
     },
     open({ state, commit }, { name, data }) {
-      changeHash(name)
+      changeHash(name, data)
       if (state.name === 'UserModal') {
         // Transition from user modal
         commit('setLastUser', state.data)
@@ -157,8 +161,8 @@ export default {
       commit('setModalName', name)
       commit('setModalData', data)
     },
-    close({ commit }) {
-      changeHash('')
+    close({ commit }, type) {
+      changeHash('', { type })
       commit('setModalName', null)
       commit('setLastUser', null)
       commit('setModalData', null)

--- a/src/store/pickerModal.js
+++ b/src/store/pickerModal.js
@@ -26,9 +26,9 @@ export default {
     setStampPickerActive(state, isActive) {
       state.stampPickerActive = isActive
       if (isActive) {
-        changeHash('PickerModal')
+        changeHash('PickerModal', {})
       } else if (location.hash === '#PickerModal') {
-        changeHash('')
+        changeHash('', { type: 'all' })
       }
     },
     setStampPickerModeAsMessage(state) {

--- a/src/store/pickerModal.js
+++ b/src/store/pickerModal.js
@@ -26,9 +26,9 @@ export default {
     setStampPickerActive(state, isActive) {
       state.stampPickerActive = isActive
       if (isActive) {
-        changeHash('PickerModal', {})
+        changeHash('PickerModal')
       } else if (location.hash === '#PickerModal') {
-        changeHash('', { type: 'all' })
+        changeHash('', null, { type: 'all' })
       }
     },
     setStampPickerModeAsMessage(state) {


### PR DESCRIPTION
- pushStateのときにちゃんとstateにモーダル用のデータを保存するようにした
  - ユーザーモーダル→タグモーダル→戻るでユーザーモーダルに戻るが可能
  - 各種モーダルから戻るでチャンネル画面に戻れる
- モーダルの外をタップして戻ったときには内部で戻るを複数回行いその次の戻るで前のチャンネルに移動するようになっている

mac chromeで動作確認