### PR TITLE
不要なconsole.errorの除去

### DIFF
--- a/src/bin/markdown-it.js
+++ b/src/bin/markdown-it.js
@@ -127,8 +127,6 @@ const renderEmoji = match => {
     )
   }
 
-  console.error(match[1])
-
   return match[0]
 }
 


### PR DESCRIPTION
メモリを食うので