### PR TITLE
fix modern mode transpile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
       - install_module
       - run:
           name: build
-          command: npm run build --morden
+          command: npm run build
 
   build-image:
     machine: true

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "traP",
   "scripts": {
     "serve": "vue-cli-service serve",
-    "build": "vue-cli-service build --morden",
+    "build": "vue-cli-service build --modern",
     "lint": "vue-cli-service lint",
     "fix": "vue-cli-service lint --fix",
     "gen-unicode_emojis": "node build/gen-unicode_emojis"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "esnext",
     "module": "esnext",
     "strict": true,
     "jsx": "preserve",


### PR DESCRIPTION
おそらくtypoのものと、

babelを使っているならtypescriptの出力はトランスパイルされていないものでよいので`target`を`es5`から`esnext`にしました(そんなに変わらないですが)
https://github.com/vuejs/vue-cli/blob/dev/packages/%40vue/cli-plugin-typescript/generator/template/tsconfig.json#L3
babelを使ってる場合だと既定では`esnext`になっているようなので

よろしくお願いします