### PR TITLE
プログレスバーがはみ出ていたのを修正

### DIFF
--- a/src/components/Main/MessageView/MessageInput.vue
+++ b/src/components/Main/MessageView/MessageInput.vue
@@ -588,6 +588,8 @@ $message-input-button-height-pc: 40px - 2px
   top: 0
   left: 0
   background-color: var(--primary-color-transparent)
+  +mq(pc)
+    border-top-left-radius: 8px
 
 .message-input-buttons-wrapper
   +mq(pc)


### PR DESCRIPTION
 - before
![image](https://user-images.githubusercontent.com/49056869/62938396-f53e6180-be09-11e9-8f2e-d034768c3bfd.png)
 - after
![image](https://user-images.githubusercontent.com/49056869/62938418-ff606000-be09-11e9-90c1-2295577db6ae.png)
左側しか修正できてませんが右側はそんなに長く表示されるものでもないので…
(同じ方法でやろうとすると100%でないときも左上がかけてしまう)

よろしくお願いします