### PR TITLE
エフェクトをかけたスタンプが縦方向にずれるのを修正

### DIFF
--- a/src/components/Main/MessageView/MessageElement/MessageElement.vue
+++ b/src/components/Main/MessageView/MessageElement/MessageElement.vue
@@ -737,6 +737,7 @@ export default {
 
 .emoji-effect
   display: inline-block
+  vertical-align: middle
 
 .emoji
   width: 1em


### PR DESCRIPTION
 - before
![image](https://user-images.githubusercontent.com/49056869/64075691-68930f00-ccf6-11e9-911f-a33ab7d08c91.png)

 - after
![image](https://user-images.githubusercontent.com/49056869/64075695-76489480-ccf6-11e9-9401-660f7024e1a7.png)

よろしくお願いします