### PR TITLE
update markdown-it-image-filter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9736,9 +9736,9 @@
       }
     },
     "markdown-it-image-filter": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/markdown-it-image-filter/-/markdown-it-image-filter-1.0.1.tgz",
-      "integrity": "sha512-5/cTN5Or/qxFD8knNQM6Uy8PrhbEFDeB6kHs3n+NIZnAMosVU6pojnqB/GYJHJUPFNZEgz/o5OgvzLhFIDRgIA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-image-filter/-/markdown-it-image-filter-1.1.0.tgz",
+      "integrity": "sha512-JwXUqgW9ySE576M8vCkajtkkeBEeKov5yT0F4o9Gd/cQrrj+UnKzVz8WIx0o3613CI8dPPcS1q44LDdZcikyGQ==",
       "dev": true
     },
     "markdown-it-json": {
@@ -10217,7 +10217,7 @@
       "dependencies": {
         "semver": {
           "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
           "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true
         }
@@ -12840,7 +12840,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "highlight.js": "^9.15.10",
     "lint-staged": "^9.2.5",
     "markdown-it": "^10.0.0",
-    "markdown-it-image-filter": "^1.0.1",
+    "markdown-it-image-filter": "^1.1.0",
     "markdown-it-json": "^1.0.2",
     "markdown-it-link-attributes": "^2.1.0",
     "markdown-it-mark": "^3.0.0",

--- a/src/worker/markdown-it.js
+++ b/src/worker/markdown-it.js
@@ -237,7 +237,7 @@ md.use(mila, {
     rel: 'nofollow noopener noreferrer'
   }
 })
-md.use(filter(whitelist))
+md.use(filter(whitelist, { httpsOnly: true }))
 
 export const render = text => {
   return md.render(text, {})


### PR DESCRIPTION
`![](https://[許可されたドメイン])`のみがimgタグに置換されるようになります。