### PR TITLE
通知が来ないへの対処

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -23,7 +23,8 @@ try {
     databaseURL: 'https://traq-r.firebaseio.com',
     projectId: 'traq-r',
     storageBucket: 'traq-r.appspot.com',
-    messagingSenderId: '993645413001'
+    messagingSenderId: '993645413001',
+    appId: '1:993645413001:web:b253ea3776d6cf85163c58'
   }
   Firebase.initializeApp(config)
 } catch (e) {


### PR DESCRIPTION
https://github.com/firebase/firebase-js-sdk/issues/2287
`appId: ${firebaseのappのID}`を`firebase.initialize`に渡さないといけない

```js
Uncaught (in promise) FirebaseError: Installations: Missing App configuration values. (installations/missing-app-config-values).
    at w (https://q.trap.jp/js/chunk-vendors.3e49f4a4.js:472:166)
    at Object.n [as installations] (https://q.trap.jp/js/chunk-vendors.3e49f4a4.js:696:62)
    at e._getService (https://q.trap.jp/js/chunk-vendors.3e49f4a4.js:933:7262)
    at e.<computed> [as installations] (https://q.trap.jp/js/chunk-vendors.3e49f4a4.js:966:1190)
    at https://q.trap.jp/js/chunk-vendors.3e49f4a4.js:745:2343
    at c (https://q.trap.jp/js/chunk-vendors.3e49f4a4.js:893:2579)
    at Object.next (https://q.trap.jp/js/chunk-vendors.3e49f4a4.js:893:1874)
    at https://q.trap.jp/js/chunk-vendors.3e49f4a4.js:893:1599
    at new Promise (<anonymous>)
    at l (https://q.trap.jp/js/chunk-vendors.3e49f4a4.js:893:1370)
```

> Breaking change: version 7.0.0 introduces a new service related to client app instance registration. **If you are currently using FCM for web and want to upgrade to SDK 7.0.0 or later, you must enable the FCM Registration API for your project in the Google Cloud Console.**
> When you enable this service, make sure you are logged in to Cloud Console with the same Google account you use for Firebase, and make sure to select the correct project. No other migration tasks are required; once the API is enabled, pre-7.0.0 apps will continue to function normally.
> [Version 7.0.0 - Firebase Javascript SDK Release Notes | Firebase](https://firebase.google.com/support/release-notes/js#version_700_-_september_26_2019)


よろしくお願いします