### PR TITLE
 fix #880 引用メッセージの文字サイズが普通より大きい

### DIFF
--- a/src/components/Main/MessageView/MessageElement/AttachedMessages.vue
+++ b/src/components/Main/MessageView/MessageElement/AttachedMessages.vue
@@ -11,7 +11,8 @@
             @click="openUserModal(m.userId)")
           p.attached-message-user-name(@click="openUserModal(m.userId)")
             | {{userDisplayName(m.userId)}}
-        component(:is="renderedBodies[index]" v-bind="$props")
+        div.attached-message-content-wrap
+          component(:is="renderedBodies[index]" v-bind="$props")
         div.attached-message-from
           | from
           router-link.attached-message-from-link(:to="parentChannel(m.parentChannelId).to")
@@ -116,6 +117,10 @@ export default {
 .attached-message-detail-wrap
   display: flex
 
+.attached-message-content-wrap
+  font:
+    size: 0.9em
+
 .attached-message-user-icon
   width: 20px
   height: 20px
@@ -138,7 +143,7 @@ export default {
   font:
     size: 0.8em
   margin:
-    top: 12px
+    top: 6px
 
 .attached-message-from-link
   margin:


### PR DESCRIPTION
引用の文字サイズを本文の文字サイズと合わせて、from部分の上の余白をちょっと詰めました。
よろしくお願いします

before:
<img width="567" alt="before880" src="https://user-images.githubusercontent.com/30363887/68354678-5c8d5880-0150-11ea-9f74-6a22b557baa9.png">

after:
<img width="565" alt="after880" src="https://user-images.githubusercontent.com/30363887/68354683-61eaa300-0150-11ea-8bbb-5e6ca371735b.png">
