### PR TITLE
コードブロックの言語がtextなどの時にauto-highlightを適用しない

### DIFF
--- a/src/worker/markdown-it.js
+++ b/src/worker/markdown-it.js
@@ -28,9 +28,14 @@ export const getInitializePromise = () => {
 function highlight(code, lang) {
   const [langName, langCaption] = lang.split(':')
   const citeTag = langCaption ? `<cite>${langCaption}</cite>` : ''
+  const noHighlightRe = /^(no-?highlight|plain|text)$/i
   if (hljs.getLanguage(langName)) {
     const result = hljs.highlight(langName, code)
     return `<pre class="traq-code traq-lang">${citeTag}<code class="lang-${result.language}">${result.value}</code></pre>`
+  } else if (noHighlightRe.test(langName)) {
+    return `<pre class="traq-code traq-lang">${citeTag}<code>${md.utils.escapeHtml(
+      code
+    )}</code></pre>`
   } else {
     const result = hljs.highlightAuto(code)
     return `<pre class="traq-code traq-lang">${citeTag}<code class="lang-${result.language}">${result.value}</code></pre>`


### PR DESCRIPTION
コードブロックにtext, plainなどを入れてもauto-highlightが適用されていたので、されないように直しました

変更後はこんな感じです
上: textを設定
下: 設定無し(auto-highlight)
<img width="190" alt="スクリーンショット 2019-11-21 17 26 00" src="https://user-images.githubusercontent.com/18257693/69320552-bfb8d800-0c84-11ea-838c-f3b592d89b42.png">

参考
https://github.com/facebook/Docusaurus/issues/874
https://github.com/markdown-it/markdown-it#syntax-highlighting

よろしくお願いします。